### PR TITLE
Locality with "Anywhere" as 1 (default)

### DIFF
--- a/LocalGlobal.agda
+++ b/LocalGlobal.agda
@@ -6,19 +6,16 @@ open import Relation.Nullary.Decidable
 open import Agda.Builtin.Bool
 
 data Locality : Set where
-  Unused : Locality -- 0
-  Local  : Locality -- 1, i.e., we can do `a [Local] -> a`
-  Global : Locality
-  Arb    : Locality
+  Unused   : Locality -- 0
+  Global   : Locality
+  Local    : Locality -- i.e. not Global
+  Anywhere : Locality -- 1 i.e. default
 
 data Ordering : Locality -> Locality -> Set where
+  GlobalToLocal    : Ordering Global   Local    -- Global   < Local
+  AnywhereToLocal  : Ordering Anywhere Local    -- Anywhere < Local
+  GlobalToAnywhere : Ordering Global   Anywhere -- Anywhere < Global
 
-  ArbToLocal    : Ordering Arb    Local -- Arb < Local
-  ArbToGlobal   : Ordering Arb    Global -- Arb < Global
-  GlobalToLocal : Ordering Global Local -- Global < Local
-
- -- Discussion: (maybe Local < Unused ?)
- -- JP: order for Unused<->Arb? 
 
 {-
 
@@ -34,28 +31,28 @@ x : Local A /|- t : B
 
 -}
 
-  ReflL         : Ordering Local  Local
-  ReflG         : Ordering Global Global
-  Refl0         : Ordering Unused Unused
-  ReflA         : Ordering Arb    Arb
+  Refl0            : Ordering Unused   Unused
+  ReflG            : Ordering Global   Global
+  ReflL            : Ordering Local    Local
+  ReflA            : Ordering Anywhere Anywhere
 
 _+l_ : Locality -> Locality -> Locality
-Unused +l y      = y
-y      +l Unused = y
-Local  +l Local  = Local
-Arb    +l y      = Arb
-y      +l Arb    = Arb
-x      +l Global = Global
-Global +l y      = Global
+Unused   +l x        = x
+x        +l Unused   = x
+Global   +l x        = Global
+x        +l Global   = Global
+Local    +l x        = Local
+x        +l Local    = Local
+Anywhere +l Anywhere = Anywhere
 
 _*l_ : Locality -> Locality -> Locality
-Unused *l y      = Unused
-y      *l Unused = Unused
-Local  *l Local  = Local
-Arb    *l x      = Arb
-x      *l Arb    = Arb
-x      *l Global = Global
-Global *l y      = Global
+Unused   *l x        = Unused
+x        *l Unused   = Unused
+Global   *l x        = Global
+x        *l Global   = Global
+Local    *l x        = Local
+x        *l Local    = Local
+Anywhere *l Anywhere = Anywhere
 
 
 {-
@@ -86,7 +83,7 @@ localGlobal : Semiring
 localGlobal =
   record
     { grade = Locality
-    ; 1R = Local  -- i.e., we can go a [Local] -> a
+    ; 1R = Anywhere
     ; 0R = Unused
     ; _+R_ = _+l_
     ; _*R_ = _*l_
@@ -109,329 +106,375 @@ localGlobal =
     ; transitive≤ = transt
     }
   where
-    reflexive : {r : Locality} → Ordering r r
-    reflexive {Local} = ReflL
-    reflexive {Global} = ReflG
+    reflexive : {r : Locality} -> Ordering r r
     reflexive {Unused} = Refl0
-    reflexive {Arb} = ReflA
+    reflexive {Global} = ReflG
+    reflexive {Local} = ReflL
+    reflexive {Anywhere} = ReflA
 
-    transt : {r s t : Locality} →
-      Ordering r s → Ordering s t → Ordering r t
+    transt : {r s t : Locality} -> 
+      Ordering r s -> Ordering s t -> Ordering r t
     transt {.Global} {.Local} {.Local} GlobalToLocal ReflL = GlobalToLocal
-    transt {.Arb} {.Local} {.Local} ArbToLocal ReflL = ArbToLocal
-    transt {.Arb} {.Global} {.Local} ArbToGlobal GlobalToLocal = ArbToLocal
-    transt {.Arb} {.Global} {.Global} ArbToGlobal ReflG = ArbToGlobal
-    transt {.Local} {.Local} {.Local} ReflL ReflL = ReflL
-    transt {.Global} {.Global} {.Local} ReflG GlobalToLocal = GlobalToLocal
-    transt {.Global} {.Global} {.Global} ReflG ReflG = ReflG
+    transt {.Anywhere} {.Local} {.Local} AnywhereToLocal ReflL = AnywhereToLocal
+    transt {.Global} {.Anywhere} {.Local} GlobalToAnywhere AnywhereToLocal = GlobalToLocal
+    transt {.Global} {.Anywhere} {.Anywhere} GlobalToAnywhere ReflA = GlobalToAnywhere
     transt {.Unused} {.Unused} {.Unused} Refl0 Refl0 = Refl0
-    transt {.Arb} {.Arb} {.Local} ReflA ArbToLocal = ArbToLocal
-    transt {.Arb} {.Arb} {.Global} ReflA ArbToGlobal = ArbToGlobal
-    transt {.Arb} {.Arb} {.Arb} ReflA ReflA = ReflA
+    transt {.Global} {.Global} {.Local} ReflG GlobalToLocal = GlobalToLocal
+    transt {.Global} {.Global} {.Anywhere} ReflG GlobalToAnywhere = GlobalToAnywhere
+    transt {.Global} {.Global} {.Global} ReflG ReflG = ReflG
+    transt {.Local} {.Local} {.Local} ReflL ReflL = ReflL
+    transt {.Anywhere} {.Anywhere} {.Local} ReflA AnywhereToLocal = AnywhereToLocal
+    transt {.Anywhere} {.Anywhere} {.Anywhere} ReflA ReflA = ReflA
 
-    dec<= :  (r s : Locality) → Dec (Ordering r s)
-    dec<= Local Local = yes ReflL
-    dec<= Local Global = no (λ ())
-    dec<= Local Arb = no (\ ())
-    dec<= Local Unused = no (\ ())
-    dec<= Global Local = yes GlobalToLocal
-    dec<= Global Global = yes ReflG
-    dec<= Global Arb = no (\ ())
-    dec<= Global Unused = no (\())
-    dec<= Arb Local = yes ArbToLocal
-    dec<= Arb Global = yes ArbToGlobal
-    dec<= Arb Arb = yes ReflA
-    dec<= Arb Unused = no (\ ())
-    dec<= Unused Local = no (\ ())
-    dec<= Unused Global = no (\())
-    dec<= Unused Arb = no (\ ())
+    dec<= :  (r s : Locality) -> Dec (Ordering r s)
     dec<= Unused Unused = yes Refl0
-
+    dec<= Unused Global = no (λ ())
+    dec<= Unused Local = no (λ ())
+    dec<= Unused Anywhere = no (λ ())
+    dec<= Global Unused = no (λ ())
+    dec<= Global Global = yes ReflG
+    dec<= Global Local = yes GlobalToLocal
+    dec<= Global Anywhere = yes GlobalToAnywhere
+    dec<= Local Unused = no (λ ())
+    dec<= Local Global = no (λ ())
+    dec<= Local Local = yes ReflL
+    dec<= Local Anywhere = no (λ ())
+    dec<= Anywhere Unused = no (λ ())
+    dec<= Anywhere Global = no (λ ())
+    dec<= Anywhere Local = yes AnywhereToLocal
+    dec<= Anywhere Anywhere = yes ReflA
 
     right+ : {x : Locality} -> (x +l Unused) ≡ x
-    right+ {Local} = refl
-    right+ {Global} = refl
     right+ {Unused} = refl
-    right+ {Arb} = refl
+    right+ {Global} = refl
+    right+ {Local} = refl
+    right+ {Anywhere} = refl
 
     commPlus : {x y : Locality} -> (x +l y) ≡ (y +l x)
-    commPlus {Local} {Local} = refl
-    commPlus {Local} {Global} = refl
-    commPlus {Local} {Unused} = refl
-    commPlus {Local} {Arb} = refl
-    commPlus {Global} {Local} = refl
-    commPlus {Global} {Global} = refl
-    commPlus {Global} {Unused} = refl
-    commPlus {Global} {Arb} = refl
-    commPlus {Unused} {Local} = refl
-    commPlus {Unused} {Global} = refl
     commPlus {Unused} {Unused} = refl
-    commPlus {Unused} {Arb} = refl
-    commPlus {Arb} {Local} = refl
-    commPlus {Arb} {Global} = refl
-    commPlus {Arb} {Unused} = refl
-    commPlus {Arb} {Arb} = refl
+    commPlus {Unused} {Global} = refl
+    commPlus {Unused} {Local} = refl
+    commPlus {Unused} {Anywhere} = refl
+    commPlus {Global} {Unused} = refl
+    commPlus {Global} {Global} = refl
+    commPlus {Global} {Local} = refl
+    commPlus {Global} {Anywhere} = refl
+    commPlus {Local} {Unused} = refl
+    commPlus {Local} {Global} = refl
+    commPlus {Local} {Local} = refl
+    commPlus {Local} {Anywhere} = refl
+    commPlus {Anywhere} {Unused} = refl
+    commPlus {Anywhere} {Global} = refl
+    commPlus {Anywhere} {Local} = refl
+    commPlus {Anywhere} {Anywhere} = refl
 
-    leftUnit* : {x : Locality} ->  (Local *l x) ≡ x
-    leftUnit* {Local} = refl
-    leftUnit* {Global} = refl
+    leftUnit* : {x : Locality} -> (Anywhere *l x) ≡ x
     leftUnit* {Unused} = refl
-    leftUnit* {Arb}    = refl
+    leftUnit* {Global} = refl
+    leftUnit* {Local} = refl
+    leftUnit* {Anywhere} = refl
 
-    rightUnit* : {x : Locality} ->  (x *l Local) ≡ x
-    rightUnit* {Local} = refl
-    rightUnit* {Global} = refl
+    rightUnit* : {x : Locality} -> (x *l Anywhere) ≡ x
     rightUnit* {Unused} = refl
-    rightUnit* {Arb} = refl
+    rightUnit* {Global} = refl
+    rightUnit* {Local} = refl
+    rightUnit* {Anywhere} = refl
 
-    rightabsorb : {x : Locality} → (x *l Unused) ≡ Unused
-    rightabsorb {Local} = refl
-    rightabsorb {Global} = refl
+    rightabsorb : {x : Locality} -> (x *l Unused) ≡ Unused
     rightabsorb {Unused} = refl
-    rightabsorb {Arb} = refl
+    rightabsorb {Global} = refl
+    rightabsorb {Local} = refl
+    rightabsorb {Anywhere} = refl
 
-    mon* : {r1 r2 s1 s2 : Locality} →
-      Ordering r1 r2 → Ordering s1 s2 → Ordering (r1 *l s1) (r2 *l s2)
+    mon* : {r1 r2 s1 s2 : Locality} ->
+      Ordering r1 r2 -> Ordering s1 s2 -> Ordering (r1 *l s1) (r2 *l s2)
     mon* {.Global} {.Local} {.Global} {.Local} GlobalToLocal GlobalToLocal = GlobalToLocal
-    mon* {.Global} {.Local} {.Arb} {.Local} GlobalToLocal ArbToLocal = ArbToLocal
-    mon* {.Global} {.Local} {.Arb} {.Global} GlobalToLocal ArbToGlobal = ArbToGlobal
-    mon* {.Global} {.Local} {.Local} {.Local} GlobalToLocal ReflL = GlobalToLocal
-    mon* {.Global} {.Local} {.Global} {.Global} GlobalToLocal ReflG = ReflG
+    mon* {.Global} {.Local} {.Anywhere} {.Local} GlobalToLocal AnywhereToLocal = GlobalToLocal
+    mon* {.Global} {.Local} {.Global} {.Anywhere} GlobalToLocal GlobalToAnywhere = GlobalToLocal
     mon* {.Global} {.Local} {.Unused} {.Unused} GlobalToLocal Refl0 = Refl0
-    mon* {.Global} {.Local} {.Arb} {.Arb} GlobalToLocal ReflA = ReflA
-    mon* {.Arb} {.Local} {.Global} {.Local} ArbToLocal GlobalToLocal = ArbToLocal
-    mon* {.Arb} {.Local} {.Arb} {.Local} ArbToLocal ArbToLocal = ArbToLocal
-    mon* {.Arb} {.Local} {.Arb} {.Global} ArbToLocal ArbToGlobal = ArbToGlobal
-    mon* {.Arb} {.Local} {.Local} {.Local} ArbToLocal ReflL = ArbToLocal
-    mon* {.Arb} {.Local} {.Global} {.Global} ArbToLocal ReflG = ArbToGlobal
-    mon* {.Arb} {.Local} {.Unused} {.Unused} ArbToLocal Refl0 = Refl0
-    mon* {.Arb} {.Local} {.Arb} {.Arb} ArbToLocal ReflA = ReflA
-    mon* {.Arb} {.Global} {.Global} {.Local} ArbToGlobal GlobalToLocal = ArbToGlobal
-    mon* {.Arb} {.Global} {.Arb} {.Local} ArbToGlobal ArbToLocal = ArbToGlobal
-    mon* {.Arb} {.Global} {.Arb} {.Global} ArbToGlobal ArbToGlobal = ArbToGlobal
-    mon* {.Arb} {.Global} {.Local} {.Local} ArbToGlobal ReflL = ArbToGlobal
-    mon* {.Arb} {.Global} {.Global} {.Global} ArbToGlobal ReflG = ArbToGlobal
-    mon* {.Arb} {.Global} {.Unused} {.Unused} ArbToGlobal Refl0 = Refl0
-    mon* {.Arb} {.Global} {.Arb} {.Arb} ArbToGlobal ReflA = ReflA
-    mon* {.Local} {.Local} {.Global} {.Local} ReflL GlobalToLocal = GlobalToLocal
-    mon* {.Local} {.Local} {.Arb} {.Local} ReflL ArbToLocal = ArbToLocal
-    mon* {.Local} {.Local} {.Arb} {.Global} ReflL ArbToGlobal = ArbToGlobal
-    mon* {.Local} {.Local} {.Local} {.Local} ReflL ReflL = ReflL
-    mon* {.Local} {.Local} {.Global} {.Global} ReflL ReflG = ReflG
-    mon* {.Local} {.Local} {.Unused} {.Unused} ReflL Refl0 = Refl0
-    mon* {.Local} {.Local} {.Arb} {.Arb} ReflL ReflA = ReflA
-    mon* {.Global} {.Global} {.Global} {.Local} ReflG GlobalToLocal = ReflG
-    mon* {.Global} {.Global} {.Arb} {.Local} ReflG ArbToLocal = ArbToGlobal
-    mon* {.Global} {.Global} {.Arb} {.Global} ReflG ArbToGlobal = ArbToGlobal
-    mon* {.Global} {.Global} {.Local} {.Local} ReflG ReflL = ReflG
-    mon* {.Global} {.Global} {.Global} {.Global} ReflG ReflG = ReflG
-    mon* {.Global} {.Global} {.Unused} {.Unused} ReflG Refl0 = Refl0
-    mon* {.Global} {.Global} {.Arb} {.Arb} ReflG ReflA = ReflA
+    mon* {.Global} {.Local} {.Global} {.Global} GlobalToLocal ReflG = ReflG
+    mon* {.Global} {.Local} {.Local} {.Local} GlobalToLocal ReflL = GlobalToLocal
+    mon* {.Global} {.Local} {.Anywhere} {.Anywhere} GlobalToLocal ReflA = GlobalToLocal
+    mon* {.Anywhere} {.Local} {.Global} {.Local} AnywhereToLocal GlobalToLocal = GlobalToLocal
+    mon* {.Anywhere} {.Local} {.Anywhere} {.Local} AnywhereToLocal AnywhereToLocal = AnywhereToLocal
+    mon* {.Anywhere} {.Local} {.Global} {.Anywhere} AnywhereToLocal GlobalToAnywhere = GlobalToLocal
+    mon* {.Anywhere} {.Local} {.Unused} {.Unused} AnywhereToLocal Refl0 = Refl0
+    mon* {.Anywhere} {.Local} {.Global} {.Global} AnywhereToLocal ReflG = ReflG
+    mon* {.Anywhere} {.Local} {.Local} {.Local} AnywhereToLocal ReflL = ReflL
+    mon* {.Anywhere} {.Local} {.Anywhere} {.Anywhere} AnywhereToLocal ReflA = AnywhereToLocal
+    mon* {.Global} {.Anywhere} {.Global} {.Local} GlobalToAnywhere GlobalToLocal = GlobalToLocal
+    mon* {.Global} {.Anywhere} {.Anywhere} {.Local} GlobalToAnywhere AnywhereToLocal = GlobalToLocal
+    mon* {.Global} {.Anywhere} {.Global} {.Anywhere} GlobalToAnywhere GlobalToAnywhere = GlobalToAnywhere
+    mon* {.Global} {.Anywhere} {.Unused} {.Unused} GlobalToAnywhere Refl0 = Refl0
+    mon* {.Global} {.Anywhere} {.Global} {.Global} GlobalToAnywhere ReflG = ReflG
+    mon* {.Global} {.Anywhere} {.Local} {.Local} GlobalToAnywhere ReflL = GlobalToLocal
+    mon* {.Global} {.Anywhere} {.Anywhere} {.Anywhere} GlobalToAnywhere ReflA = GlobalToAnywhere
     mon* {.Unused} {.Unused} {.Global} {.Local} Refl0 GlobalToLocal = Refl0
-    mon* {.Unused} {.Unused} {.Arb} {.Local} Refl0 ArbToLocal = Refl0
-    mon* {.Unused} {.Unused} {.Arb} {.Global} Refl0 ArbToGlobal = Refl0
-    mon* {.Unused} {.Unused} {.Local} {.Local} Refl0 ReflL = Refl0
-    mon* {.Unused} {.Unused} {.Global} {.Global} Refl0 ReflG = Refl0
+    mon* {.Unused} {.Unused} {.Anywhere} {.Local} Refl0 AnywhereToLocal = Refl0
+    mon* {.Unused} {.Unused} {.Global} {.Anywhere} Refl0 GlobalToAnywhere = Refl0
     mon* {.Unused} {.Unused} {.Unused} {.Unused} Refl0 Refl0 = Refl0
-    mon* {.Unused} {.Unused} {.Arb} {.Arb} Refl0 ReflA = Refl0
-    mon* {.Arb} {.Arb} {.Global} {.Local} ReflA GlobalToLocal = ReflA
-    mon* {.Arb} {.Arb} {.Arb} {.Local} ReflA ArbToLocal = ReflA
-    mon* {.Arb} {.Arb} {.Arb} {.Global} ReflA ArbToGlobal = ReflA
-    mon* {.Arb} {.Arb} {.Local} {.Local} ReflA ReflL = ReflA
-    mon* {.Arb} {.Arb} {.Global} {.Global} ReflA ReflG = ReflA
-    mon* {.Arb} {.Arb} {.Unused} {.Unused} ReflA Refl0 = Refl0
-    mon* {.Arb} {.Arb} {.Arb} {.Arb} ReflA ReflA = ReflA
+    mon* {.Unused} {.Unused} {.Global} {.Global} Refl0 ReflG = Refl0
+    mon* {.Unused} {.Unused} {.Local} {.Local} Refl0 ReflL = Refl0
+    mon* {.Unused} {.Unused} {.Anywhere} {.Anywhere} Refl0 ReflA = Refl0
+    mon* {.Global} {.Global} {.Global} {.Local} ReflG GlobalToLocal = ReflG
+    mon* {.Global} {.Global} {.Anywhere} {.Local} ReflG AnywhereToLocal = ReflG
+    mon* {.Global} {.Global} {.Global} {.Anywhere} ReflG GlobalToAnywhere = ReflG
+    mon* {.Global} {.Global} {.Unused} {.Unused} ReflG Refl0 = Refl0
+    mon* {.Global} {.Global} {.Global} {.Global} ReflG ReflG = ReflG
+    mon* {.Global} {.Global} {.Local} {.Local} ReflG ReflL = ReflG
+    mon* {.Global} {.Global} {.Anywhere} {.Anywhere} ReflG ReflA = ReflG
+    mon* {.Local} {.Local} {.Global} {.Local} ReflL GlobalToLocal = GlobalToLocal
+    mon* {.Local} {.Local} {.Anywhere} {.Local} ReflL AnywhereToLocal = ReflL
+    mon* {.Local} {.Local} {.Global} {.Anywhere} ReflL GlobalToAnywhere = GlobalToLocal
+    mon* {.Local} {.Local} {.Unused} {.Unused} ReflL Refl0 = Refl0
+    mon* {.Local} {.Local} {.Global} {.Global} ReflL ReflG = ReflG
+    mon* {.Local} {.Local} {.Local} {.Local} ReflL ReflL = ReflL
+    mon* {.Local} {.Local} {.Anywhere} {.Anywhere} ReflL ReflA = ReflL
+    mon* {.Anywhere} {.Anywhere} {.Global} {.Local} ReflA GlobalToLocal = GlobalToLocal
+    mon* {.Anywhere} {.Anywhere} {.Anywhere} {.Local} ReflA AnywhereToLocal = AnywhereToLocal
+    mon* {.Anywhere} {.Anywhere} {.Global} {.Anywhere} ReflA GlobalToAnywhere = GlobalToAnywhere
+    mon* {.Anywhere} {.Anywhere} {.Unused} {.Unused} ReflA Refl0 = Refl0
+    mon* {.Anywhere} {.Anywhere} {.Global} {.Global} ReflA ReflG = ReflG
+    mon* {.Anywhere} {.Anywhere} {.Local} {.Local} ReflA ReflL = ReflL
+    mon* {.Anywhere} {.Anywhere} {.Anywhere} {.Anywhere} ReflA ReflA = ReflA
 
-    mon+ : {r1 r2 s1 s2 : Locality} →
-      Ordering r1 r2 → Ordering s1 s2 → Ordering (r1 +l s1) (r2 +l s2)
+    mon+ : {r1 r2 s1 s2 : Locality} ->
+      Ordering r1 r2 -> Ordering s1 s2 -> Ordering (r1 +l s1) (r2 +l s2)
     mon+ {.Global} {.Local} {.Global} {.Local} GlobalToLocal GlobalToLocal = GlobalToLocal
-    mon+ {.Global} {.Local} {.Arb} {.Local} GlobalToLocal ArbToLocal = ArbToLocal
-    mon+ {.Global} {.Local} {.Arb} {.Global} GlobalToLocal ArbToGlobal = ArbToGlobal
-    mon+ {.Global} {.Local} {.Local} {.Local} GlobalToLocal ReflL = GlobalToLocal
-    mon+ {.Global} {.Local} {.Global} {.Global} GlobalToLocal ReflG = ReflG
+    mon+ {.Global} {.Local} {.Anywhere} {.Local} GlobalToLocal AnywhereToLocal = GlobalToLocal
+    mon+ {.Global} {.Local} {.Global} {.Anywhere} GlobalToLocal GlobalToAnywhere = GlobalToLocal
     mon+ {.Global} {.Local} {.Unused} {.Unused} GlobalToLocal Refl0 = GlobalToLocal
-    mon+ {.Global} {.Local} {.Arb} {.Arb} GlobalToLocal ReflA = ReflA
-    mon+ {.Arb} {.Local} {.Global} {.Local} ArbToLocal GlobalToLocal = ArbToLocal
-    mon+ {.Arb} {.Local} {.Arb} {.Local} ArbToLocal ArbToLocal = ArbToLocal
-    mon+ {.Arb} {.Local} {.Arb} {.Global} ArbToLocal ArbToGlobal = ArbToGlobal
-    mon+ {.Arb} {.Local} {.Local} {.Local} ArbToLocal ReflL = ArbToLocal
-    mon+ {.Arb} {.Local} {.Global} {.Global} ArbToLocal ReflG = ArbToGlobal
-    mon+ {.Arb} {.Local} {.Unused} {.Unused} ArbToLocal Refl0 = ArbToLocal
-    mon+ {.Arb} {.Local} {.Arb} {.Arb} ArbToLocal ReflA = ReflA
-    mon+ {.Arb} {.Global} {.Global} {.Local} ArbToGlobal GlobalToLocal = ArbToGlobal
-    mon+ {.Arb} {.Global} {.Arb} {.Local} ArbToGlobal ArbToLocal = ArbToGlobal
-    mon+ {.Arb} {.Global} {.Arb} {.Global} ArbToGlobal ArbToGlobal = ArbToGlobal
-    mon+ {.Arb} {.Global} {.Local} {.Local} ArbToGlobal ReflL = ArbToGlobal
-    mon+ {.Arb} {.Global} {.Global} {.Global} ArbToGlobal ReflG = ArbToGlobal
-    mon+ {.Arb} {.Global} {.Unused} {.Unused} ArbToGlobal Refl0 = ArbToGlobal
-    mon+ {.Arb} {.Global} {.Arb} {.Arb} ArbToGlobal ReflA = ReflA
-    mon+ {.Local} {.Local} {.Global} {.Local} ReflL GlobalToLocal = GlobalToLocal
-    mon+ {.Local} {.Local} {.Arb} {.Local} ReflL ArbToLocal = ArbToLocal
-    mon+ {.Local} {.Local} {.Arb} {.Global} ReflL ArbToGlobal = ArbToGlobal
-    mon+ {.Local} {.Local} {.Local} {.Local} ReflL ReflL = ReflL
-    mon+ {.Local} {.Local} {.Global} {.Global} ReflL ReflG = ReflG
-    mon+ {.Local} {.Local} {.Unused} {.Unused} ReflL Refl0 = ReflL
-    mon+ {.Local} {.Local} {.Arb} {.Arb} ReflL ReflA = ReflA
-    mon+ {.Global} {.Global} {.Global} {.Local} ReflG GlobalToLocal = ReflG
-    mon+ {.Global} {.Global} {.Arb} {.Local} ReflG ArbToLocal = ArbToGlobal
-    mon+ {.Global} {.Global} {.Arb} {.Global} ReflG ArbToGlobal = ArbToGlobal
-    mon+ {.Global} {.Global} {.Local} {.Local} ReflG ReflL = ReflG
-    mon+ {.Global} {.Global} {.Global} {.Global} ReflG ReflG = ReflG
-    mon+ {.Global} {.Global} {.Unused} {.Unused} ReflG Refl0 = ReflG
-    mon+ {.Global} {.Global} {.Arb} {.Arb} ReflG ReflA = ReflA
+    mon+ {.Global} {.Local} {.Global} {.Global} GlobalToLocal ReflG = ReflG
+    mon+ {.Global} {.Local} {.Local} {.Local} GlobalToLocal ReflL = GlobalToLocal
+    mon+ {.Global} {.Local} {.Anywhere} {.Anywhere} GlobalToLocal ReflA = GlobalToLocal
+    mon+ {.Anywhere} {.Local} {.Global} {.Local} AnywhereToLocal GlobalToLocal = GlobalToLocal
+    mon+ {.Anywhere} {.Local} {.Anywhere} {.Local} AnywhereToLocal AnywhereToLocal = AnywhereToLocal
+    mon+ {.Anywhere} {.Local} {.Global} {.Anywhere} AnywhereToLocal GlobalToAnywhere = GlobalToLocal
+    mon+ {.Anywhere} {.Local} {.Unused} {.Unused} AnywhereToLocal Refl0 = AnywhereToLocal
+    mon+ {.Anywhere} {.Local} {.Global} {.Global} AnywhereToLocal ReflG = ReflG
+    mon+ {.Anywhere} {.Local} {.Local} {.Local} AnywhereToLocal ReflL = ReflL
+    mon+ {.Anywhere} {.Local} {.Anywhere} {.Anywhere} AnywhereToLocal ReflA = AnywhereToLocal
+    mon+ {.Global} {.Anywhere} {.Global} {.Local} GlobalToAnywhere GlobalToLocal = GlobalToLocal
+    mon+ {.Global} {.Anywhere} {.Anywhere} {.Local} GlobalToAnywhere AnywhereToLocal = GlobalToLocal
+    mon+ {.Global} {.Anywhere} {.Global} {.Anywhere} GlobalToAnywhere GlobalToAnywhere = GlobalToAnywhere
+    mon+ {.Global} {.Anywhere} {.Unused} {.Unused} GlobalToAnywhere Refl0 = GlobalToAnywhere
+    mon+ {.Global} {.Anywhere} {.Global} {.Global} GlobalToAnywhere ReflG = ReflG
+    mon+ {.Global} {.Anywhere} {.Local} {.Local} GlobalToAnywhere ReflL = GlobalToLocal
+    mon+ {.Global} {.Anywhere} {.Anywhere} {.Anywhere} GlobalToAnywhere ReflA = GlobalToAnywhere
     mon+ {.Unused} {.Unused} {.Global} {.Local} Refl0 GlobalToLocal = GlobalToLocal
-    mon+ {.Unused} {.Unused} {.Arb} {.Local} Refl0 ArbToLocal = ArbToLocal
-    mon+ {.Unused} {.Unused} {.Arb} {.Global} Refl0 ArbToGlobal = ArbToGlobal
-    mon+ {.Unused} {.Unused} {.Local} {.Local} Refl0 ReflL = ReflL
-    mon+ {.Unused} {.Unused} {.Global} {.Global} Refl0 ReflG = ReflG
+    mon+ {.Unused} {.Unused} {.Anywhere} {.Local} Refl0 AnywhereToLocal = AnywhereToLocal
+    mon+ {.Unused} {.Unused} {.Global} {.Anywhere} Refl0 GlobalToAnywhere = GlobalToAnywhere
     mon+ {.Unused} {.Unused} {.Unused} {.Unused} Refl0 Refl0 = Refl0
-    mon+ {.Unused} {.Unused} {.Arb} {.Arb} Refl0 ReflA = ReflA
-    mon+ {.Arb} {.Arb} {.Global} {.Local} ReflA GlobalToLocal = ReflA
-    mon+ {.Arb} {.Arb} {.Arb} {.Local} ReflA ArbToLocal = ReflA
-    mon+ {.Arb} {.Arb} {.Arb} {.Global} ReflA ArbToGlobal = ReflA
-    mon+ {.Arb} {.Arb} {.Local} {.Local} ReflA ReflL = ReflA
-    mon+ {.Arb} {.Arb} {.Global} {.Global} ReflA ReflG = ReflA
-    mon+ {.Arb} {.Arb} {.Unused} {.Unused} ReflA Refl0 = ReflA
-    mon+ {.Arb} {.Arb} {.Arb} {.Arb} ReflA ReflA = ReflA
+    mon+ {.Unused} {.Unused} {.Global} {.Global} Refl0 ReflG = ReflG
+    mon+ {.Unused} {.Unused} {.Local} {.Local} Refl0 ReflL = ReflL
+    mon+ {.Unused} {.Unused} {.Anywhere} {.Anywhere} Refl0 ReflA = ReflA
+    mon+ {.Global} {.Global} {.Global} {.Local} ReflG GlobalToLocal = ReflG
+    mon+ {.Global} {.Global} {.Anywhere} {.Local} ReflG AnywhereToLocal = ReflG
+    mon+ {.Global} {.Global} {.Global} {.Anywhere} ReflG GlobalToAnywhere = ReflG
+    mon+ {.Global} {.Global} {.Unused} {.Unused} ReflG Refl0 = ReflG
+    mon+ {.Global} {.Global} {.Global} {.Global} ReflG ReflG = ReflG
+    mon+ {.Global} {.Global} {.Local} {.Local} ReflG ReflL = ReflG
+    mon+ {.Global} {.Global} {.Anywhere} {.Anywhere} ReflG ReflA = ReflG
+    mon+ {.Local} {.Local} {.Global} {.Local} ReflL GlobalToLocal = GlobalToLocal
+    mon+ {.Local} {.Local} {.Anywhere} {.Local} ReflL AnywhereToLocal = ReflL
+    mon+ {.Local} {.Local} {.Global} {.Anywhere} ReflL GlobalToAnywhere = GlobalToLocal
+    mon+ {.Local} {.Local} {.Unused} {.Unused} ReflL Refl0 = ReflL
+    mon+ {.Local} {.Local} {.Global} {.Global} ReflL ReflG = ReflG
+    mon+ {.Local} {.Local} {.Local} {.Local} ReflL ReflL = ReflL
+    mon+ {.Local} {.Local} {.Anywhere} {.Anywhere} ReflL ReflA = ReflL
+    mon+ {.Anywhere} {.Anywhere} {.Global} {.Local} ReflA GlobalToLocal = GlobalToLocal
+    mon+ {.Anywhere} {.Anywhere} {.Anywhere} {.Local} ReflA AnywhereToLocal = AnywhereToLocal
+    mon+ {.Anywhere} {.Anywhere} {.Global} {.Anywhere} ReflA GlobalToAnywhere = GlobalToAnywhere
+    mon+ {.Anywhere} {.Anywhere} {.Unused} {.Unused} ReflA Refl0 = ReflA
+    mon+ {.Anywhere} {.Anywhere} {.Global} {.Global} ReflA ReflG = ReflG
+    mon+ {.Anywhere} {.Anywhere} {.Local} {.Local} ReflA ReflL = ReflL
+    mon+ {.Anywhere} {.Anywhere} {.Anywhere} {.Anywhere} ReflA ReflA = ReflA
 
-    assoc* : {r s t : Locality} → ((r *l s) *l t) ≡ (r *l (s *l t))
-    assoc* {Local} {Local} {Local} = refl
-    assoc* {Local} {Local} {Global} = refl
-    assoc* {Local} {Local} {Arb} = refl
-    assoc* {Local} {Local} {Unused} = refl
-    assoc* {Local} {Global} {Local} = refl
-    assoc* {Local} {Global} {Global} = refl
-    assoc* {Local} {Global} {Arb} = refl
-    assoc* {Local} {Global} {Unused} = refl
-    assoc* {Local} {Arb} {Local} = refl
-    assoc* {Local} {Arb} {Global} = refl
-    assoc* {Local} {Arb} {Arb} = refl
-    assoc* {Local} {Arb} {Unused} = refl
-    assoc* {Local} {Unused} {t} = refl
-    assoc* {Global} {Local} {Local} = refl
-    assoc* {Global} {Local} {Global} = refl
-    assoc* {Global} {Local} {Arb} = refl
-    assoc* {Global} {Local} {Unused} = refl
-    assoc* {Global} {Global} {Local} = refl
-    assoc* {Global} {Global} {Global} = refl
-    assoc* {Global} {Global} {Arb} = refl
+    assoc* : {r s t : Locality} -> ((r *l s) *l t) ≡ (r *l (s *l t))
+    assoc* {Unused} {Unused} {Unused} = refl
+    assoc* {Unused} {Unused} {Global} = refl
+    assoc* {Unused} {Unused} {Local} = refl
+    assoc* {Unused} {Unused} {Anywhere} = refl
+    assoc* {Unused} {Global} {Unused} = refl
+    assoc* {Unused} {Global} {Global} = refl
+    assoc* {Unused} {Global} {Local} = refl
+    assoc* {Unused} {Global} {Anywhere} = refl
+    assoc* {Unused} {Local} {Unused} = refl
+    assoc* {Unused} {Local} {Global} = refl
+    assoc* {Unused} {Local} {Local} = refl
+    assoc* {Unused} {Local} {Anywhere} = refl
+    assoc* {Unused} {Anywhere} {Unused} = refl
+    assoc* {Unused} {Anywhere} {Global} = refl
+    assoc* {Unused} {Anywhere} {Local} = refl
+    assoc* {Unused} {Anywhere} {Anywhere} = refl
+    assoc* {Global} {Unused} {Unused} = refl
+    assoc* {Global} {Unused} {Global} = refl
+    assoc* {Global} {Unused} {Local} = refl
+    assoc* {Global} {Unused} {Anywhere} = refl
     assoc* {Global} {Global} {Unused} = refl
-    assoc* {Global} {Arb} {Local} = refl
-    assoc* {Global} {Arb} {Global} = refl
-    assoc* {Global} {Arb} {Arb} = refl
-    assoc* {Global} {Arb} {Unused} = refl
-    assoc* {Global} {Unused} {t} = refl
-    assoc* {Arb} {Local} {Local} = refl
-    assoc* {Arb} {Local} {Global} = refl
-    assoc* {Arb} {Local} {Arb} = refl
-    assoc* {Arb} {Local} {Unused} = refl
-    assoc* {Arb} {Global} {Local} = refl
-    assoc* {Arb} {Global} {Global} = refl
-    assoc* {Arb} {Global} {Arb} = refl
-    assoc* {Arb} {Global} {Unused} = refl
-    assoc* {Arb} {Arb} {Local} = refl
-    assoc* {Arb} {Arb} {Global} = refl
-    assoc* {Arb} {Arb} {Arb} = refl
-    assoc* {Arb} {Arb} {Unused} = refl
-    assoc* {Arb} {Unused} {t} = refl
-    assoc* {Unused} {s} {t} = refl
+    assoc* {Global} {Global} {Global} = refl
+    assoc* {Global} {Global} {Local} = refl
+    assoc* {Global} {Global} {Anywhere} = refl
+    assoc* {Global} {Local} {Unused} = refl
+    assoc* {Global} {Local} {Global} = refl
+    assoc* {Global} {Local} {Local} = refl
+    assoc* {Global} {Local} {Anywhere} = refl
+    assoc* {Global} {Anywhere} {Unused} = refl
+    assoc* {Global} {Anywhere} {Global} = refl
+    assoc* {Global} {Anywhere} {Local} = refl
+    assoc* {Global} {Anywhere} {Anywhere} = refl
+    assoc* {Local} {Unused} {Unused} = refl
+    assoc* {Local} {Unused} {Global} = refl
+    assoc* {Local} {Unused} {Local} = refl
+    assoc* {Local} {Unused} {Anywhere} = refl
+    assoc* {Local} {Global} {Unused} = refl
+    assoc* {Local} {Global} {Global} = refl
+    assoc* {Local} {Global} {Local} = refl
+    assoc* {Local} {Global} {Anywhere} = refl
+    assoc* {Local} {Local} {Unused} = refl
+    assoc* {Local} {Local} {Global} = refl
+    assoc* {Local} {Local} {Local} = refl
+    assoc* {Local} {Local} {Anywhere} = refl
+    assoc* {Local} {Anywhere} {Unused} = refl
+    assoc* {Local} {Anywhere} {Global} = refl
+    assoc* {Local} {Anywhere} {Local} = refl
+    assoc* {Local} {Anywhere} {Anywhere} = refl
+    assoc* {Anywhere} {Unused} {Unused} = refl
+    assoc* {Anywhere} {Unused} {Global} = refl
+    assoc* {Anywhere} {Unused} {Local} = refl
+    assoc* {Anywhere} {Unused} {Anywhere} = refl
+    assoc* {Anywhere} {Global} {Unused} = refl
+    assoc* {Anywhere} {Global} {Global} = refl
+    assoc* {Anywhere} {Global} {Local} = refl
+    assoc* {Anywhere} {Global} {Anywhere} = refl
+    assoc* {Anywhere} {Local} {Unused} = refl
+    assoc* {Anywhere} {Local} {Global} = refl
+    assoc* {Anywhere} {Local} {Local} = refl
+    assoc* {Anywhere} {Local} {Anywhere} = refl
+    assoc* {Anywhere} {Anywhere} {Unused} = refl
+    assoc* {Anywhere} {Anywhere} {Global} = refl
+    assoc* {Anywhere} {Anywhere} {Local} = refl
+    assoc* {Anywhere} {Anywhere} {Anywhere} = refl
 
-    distrib1 : {r s t : Locality} → (r *l (s +l t)) ≡ ((r *l s) +l (r *l t))
-    distrib1 {Local} {s} {t} rewrite leftUnit* {s +l t} | leftUnit* {s} | leftUnit* {t} = refl
-    distrib1 {Global} {Local} {Local} = refl
-    distrib1 {Global} {Local} {Global} = refl
-    distrib1 {Global} {Local} {Arb} = refl
-    distrib1 {Global} {Local} {Unused} = refl
-    distrib1 {Global} {Global} {Local} = refl
-    distrib1 {Global} {Global} {Global} = refl
-    distrib1 {Global} {Global} {Arb} = refl
-    distrib1 {Global} {Global} {Unused} = refl
-    distrib1 {Global} {Arb} {Local} = refl
-    distrib1 {Global} {Arb} {Global} = refl
-    distrib1 {Global} {Arb} {Arb} = refl
-    distrib1 {Global} {Arb} {Unused} = refl
-    distrib1 {Global} {Unused} {Local} = refl
-    distrib1 {Global} {Unused} {Global} = refl
-    distrib1 {Global} {Unused} {Arb} = refl
-    distrib1 {Global} {Unused} {Unused} = refl
-    distrib1 {Arb} {Local} {Local} = refl
-    distrib1 {Arb} {Local} {Global} = refl
-    distrib1 {Arb} {Local} {Arb} = refl
-    distrib1 {Arb} {Local} {Unused} = refl
-    distrib1 {Arb} {Global} {Local} = refl
-    distrib1 {Arb} {Global} {Global} = refl
-    distrib1 {Arb} {Global} {Arb} = refl
-    distrib1 {Arb} {Global} {Unused} = refl
-    distrib1 {Arb} {Arb} {Local} = refl
-    distrib1 {Arb} {Arb} {Global} = refl
-    distrib1 {Arb} {Arb} {Arb} = refl
-    distrib1 {Arb} {Arb} {Unused} = refl
-    distrib1 {Arb} {Unused} {Local} = refl
-    distrib1 {Arb} {Unused} {Global} = refl
-    distrib1 {Arb} {Unused} {Arb} = refl
-    distrib1 {Arb} {Unused} {Unused} = refl
+    distrib1 : {r s t : Locality} -> (r *l (s +l t)) ≡ ((r *l s) +l (r *l t))
     distrib1 {Unused} {s} {t} = refl
+    distrib1 {Global} {Unused} {Unused} = refl
+    distrib1 {Global} {Unused} {Global} = refl
+    distrib1 {Global} {Unused} {Local} = refl
+    distrib1 {Global} {Unused} {Anywhere} = refl
+    distrib1 {Global} {Global} {Unused} = refl
+    distrib1 {Global} {Global} {Global} = refl
+    distrib1 {Global} {Global} {Local} = refl
+    distrib1 {Global} {Global} {Anywhere} = refl
+    distrib1 {Global} {Local} {Unused} = refl
+    distrib1 {Global} {Local} {Global} = refl
+    distrib1 {Global} {Local} {Local} = refl
+    distrib1 {Global} {Local} {Anywhere} = refl
+    distrib1 {Global} {Anywhere} {Unused} = refl
+    distrib1 {Global} {Anywhere} {Global} = refl
+    distrib1 {Global} {Anywhere} {Local} = refl
+    distrib1 {Global} {Anywhere} {Anywhere} = refl
+    distrib1 {Local} {Unused} {Unused} = refl
+    distrib1 {Local} {Unused} {Global} = refl
+    distrib1 {Local} {Unused} {Local} = refl
+    distrib1 {Local} {Unused} {Anywhere} = refl
+    distrib1 {Local} {Global} {Unused} = refl
+    distrib1 {Local} {Global} {Global} = refl
+    distrib1 {Local} {Global} {Local} = refl
+    distrib1 {Local} {Global} {Anywhere} = refl
+    distrib1 {Local} {Local} {Unused} = refl
+    distrib1 {Local} {Local} {Global} = refl
+    distrib1 {Local} {Local} {Local} = refl
+    distrib1 {Local} {Local} {Anywhere} = refl
+    distrib1 {Local} {Anywhere} {Unused} = refl
+    distrib1 {Local} {Anywhere} {Global} = refl
+    distrib1 {Local} {Anywhere} {Local} = refl
+    distrib1 {Local} {Anywhere} {Anywhere} = refl
+    distrib1 {Anywhere} {s} {t} rewrite leftUnit* {s +l t} | leftUnit* {s} | leftUnit* {t} = refl
 
-    -- used by distrib2
     comm* : {x y : Locality} -> x *l y ≡ y *l x
-    comm* {Local} {Local} = refl
-    comm* {Local} {Global} = refl
-    comm* {Local} {Arb} = refl
-    comm* {Local} {Unused} = refl
-    comm* {Global} {Local} = refl
-    comm* {Global} {Global} = refl
-    comm* {Global} {Arb} = refl
-    comm* {Global} {Unused} = refl
-    comm* {Arb} {Local} = refl
-    comm* {Arb} {Global} = refl
-    comm* {Arb} {Arb} = refl
-    comm* {Arb} {Unused} = refl
-    comm* {Unused} {Local} = refl
-    comm* {Unused} {Global} = refl
-    comm* {Unused} {Arb} = refl
     comm* {Unused} {Unused} = refl
+    comm* {Unused} {Global} = refl
+    comm* {Unused} {Local} = refl
+    comm* {Unused} {Anywhere} = refl
+    comm* {Global} {Unused} = refl
+    comm* {Global} {Global} = refl
+    comm* {Global} {Local} = refl
+    comm* {Global} {Anywhere} = refl
+    comm* {Local} {Unused} = refl
+    comm* {Local} {Global} = refl
+    comm* {Local} {Local} = refl
+    comm* {Local} {Anywhere} = refl
+    comm* {Anywhere} {Unused} = refl
+    comm* {Anywhere} {Global} = refl
+    comm* {Anywhere} {Local} = refl
+    comm* {Anywhere} {Anywhere} = refl
 
-    distrib2prop : {r s t : Locality} → ((r +l s) *l t) ≡ ((r *l t) +l (s *l t))
+    distrib2prop : {r s t : Locality} -> ((r +l s) *l t) ≡ ((r *l t) +l (s *l t))
     distrib2prop {r} {s} {t} rewrite comm* {r +l s} {t} | comm* {r} {t} | comm* {s} {t} = distrib1
 
-    assocPlus : {r s t : Locality} → ((r +l s) +l t) ≡ (r +l (s +l t))
-    assocPlus {Local} {Local} {Local} = refl
-    assocPlus {Local} {Local} {Global} = refl
-    assocPlus {Local} {Local} {Arb} = refl
-    assocPlus {Local} {Local} {Unused} = refl
-    assocPlus {Local} {Global} {Local} = refl
-    assocPlus {Local} {Global} {Global} = refl
-    assocPlus {Local} {Global} {Arb} = refl
-    assocPlus {Local} {Global} {Unused} = refl
-    assocPlus {Local} {Arb} {Local} = refl
-    assocPlus {Local} {Arb} {Global} = refl
-    assocPlus {Local} {Arb} {Arb} = refl
-    assocPlus {Local} {Arb} {Unused} = refl
-    assocPlus {Local} {Unused} {t} = refl
-    assocPlus {Global} {Local} {Local} = refl
-    assocPlus {Global} {Local} {Global} = refl
-    assocPlus {Global} {Local} {Arb} = refl
-    assocPlus {Global} {Local} {Unused} = refl
-    assocPlus {Global} {Global} {Local} = refl
-    assocPlus {Global} {Global} {Global} = refl
-    assocPlus {Global} {Global} {Arb} = refl
+    assocPlus : {r s t : Locality} -> ((r +l s) +l t) ≡ (r +l (s +l t))
+    assocPlus {Unused} {Unused} {Unused} = refl
+    assocPlus {Unused} {Unused} {Global} = refl
+    assocPlus {Unused} {Unused} {Local} = refl
+    assocPlus {Unused} {Unused} {Anywhere} = refl
+    assocPlus {Unused} {Global} {Unused} = refl
+    assocPlus {Unused} {Global} {Global} = refl
+    assocPlus {Unused} {Global} {Local} = refl
+    assocPlus {Unused} {Global} {Anywhere} = refl
+    assocPlus {Unused} {Local} {Unused} = refl
+    assocPlus {Unused} {Local} {Global} = refl
+    assocPlus {Unused} {Local} {Local} = refl
+    assocPlus {Unused} {Local} {Anywhere} = refl
+    assocPlus {Unused} {Anywhere} {Unused} = refl
+    assocPlus {Unused} {Anywhere} {Global} = refl
+    assocPlus {Unused} {Anywhere} {Local} = refl
+    assocPlus {Unused} {Anywhere} {Anywhere} = refl
+    assocPlus {Global} {Unused} {Unused} = refl
+    assocPlus {Global} {Unused} {Global} = refl
+    assocPlus {Global} {Unused} {Local} = refl
+    assocPlus {Global} {Unused} {Anywhere} = refl
     assocPlus {Global} {Global} {Unused} = refl
-    assocPlus {Global} {Arb} {Local} = refl
-    assocPlus {Global} {Arb} {Global} = refl
-    assocPlus {Global} {Arb} {Arb} = refl
-    assocPlus {Global} {Arb} {Unused} = refl
-    assocPlus {Global} {Unused} {t} = refl
-    assocPlus {Arb} {Local} {Local} = refl
-    assocPlus {Arb} {Local} {Global} = refl
-    assocPlus {Arb} {Local} {Arb} = refl
-    assocPlus {Arb} {Local} {Unused} = refl
-    assocPlus {Arb} {Global} {Local} = refl
-    assocPlus {Arb} {Global} {Global} = refl
-    assocPlus {Arb} {Global} {Arb} = refl
-    assocPlus {Arb} {Global} {Unused} = refl
-    assocPlus {Arb} {Arb} {Local} = refl
-    assocPlus {Arb} {Arb} {Global} = refl
-    assocPlus {Arb} {Arb} {Arb} = refl
-    assocPlus {Arb} {Arb} {Unused} = refl
-    assocPlus {Arb} {Unused} {t} = refl
-    assocPlus {Unused} {s} {t} = refl
+    assocPlus {Global} {Global} {Global} = refl
+    assocPlus {Global} {Global} {Local} = refl
+    assocPlus {Global} {Global} {Anywhere} = refl
+    assocPlus {Global} {Local} {Unused} = refl
+    assocPlus {Global} {Local} {Global} = refl
+    assocPlus {Global} {Local} {Local} = refl
+    assocPlus {Global} {Local} {Anywhere} = refl
+    assocPlus {Global} {Anywhere} {Unused} = refl
+    assocPlus {Global} {Anywhere} {Global} = refl
+    assocPlus {Global} {Anywhere} {Local} = refl
+    assocPlus {Global} {Anywhere} {Anywhere} = refl
+    assocPlus {Local} {Unused} {Unused} = refl
+    assocPlus {Local} {Unused} {Global} = refl
+    assocPlus {Local} {Unused} {Local} = refl
+    assocPlus {Local} {Unused} {Anywhere} = refl
+    assocPlus {Local} {Global} {Unused} = refl
+    assocPlus {Local} {Global} {Global} = refl
+    assocPlus {Local} {Global} {Local} = refl
+    assocPlus {Local} {Global} {Anywhere} = refl
+    assocPlus {Local} {Local} {Unused} = refl
+    assocPlus {Local} {Local} {Global} = refl
+    assocPlus {Local} {Local} {Local} = refl
+    assocPlus {Local} {Local} {Anywhere} = refl
+    assocPlus {Local} {Anywhere} {Unused} = refl
+    assocPlus {Local} {Anywhere} {Global} = refl
+    assocPlus {Local} {Anywhere} {Local} = refl
+    assocPlus {Local} {Anywhere} {Anywhere} = refl
+    assocPlus {Anywhere} {Unused} {Unused} = refl
+    assocPlus {Anywhere} {Unused} {Global} = refl
+    assocPlus {Anywhere} {Unused} {Local} = refl
+    assocPlus {Anywhere} {Unused} {Anywhere} = refl
+    assocPlus {Anywhere} {Global} {Unused} = refl
+    assocPlus {Anywhere} {Global} {Global} = refl
+    assocPlus {Anywhere} {Global} {Local} = refl
+    assocPlus {Anywhere} {Global} {Anywhere} = refl
+    assocPlus {Anywhere} {Local} {Unused} = refl
+    assocPlus {Anywhere} {Local} {Global} = refl
+    assocPlus {Anywhere} {Local} {Local} = refl
+    assocPlus {Anywhere} {Local} {Anywhere} = refl
+    assocPlus {Anywhere} {Anywhere} {Unused} = refl
+    assocPlus {Anywhere} {Anywhere} {Global} = refl
+    assocPlus {Anywhere} {Anywhere} {Local} = refl
+    assocPlus {Anywhere} {Anywhere} {Anywhere} = refl

--- a/LocalGlobal.agda
+++ b/LocalGlobal.agda
@@ -14,7 +14,7 @@ data Locality : Set where
 data Ordering : Locality -> Locality -> Set where
   GlobalToLocal    : Ordering Global   Local    -- Global   < Local
   AnywhereToLocal  : Ordering Anywhere Local    -- Anywhere < Local
-  GlobalToAnywhere : Ordering Global   Anywhere -- Anywhere < Global
+  GlobalToAnywhere : Ordering Global   Anywhere -- Global   < Anywhere
 
 
 {-
@@ -112,7 +112,7 @@ localGlobal =
     reflexive {Local} = ReflL
     reflexive {Anywhere} = ReflA
 
-    transt : {r s t : Locality} -> 
+    transt : {r s t : Locality} ->
       Ordering r s -> Ordering s t -> Ordering r t
     transt {.Global} {.Local} {.Local} GlobalToLocal ReflL = GlobalToLocal
     transt {.Anywhere} {.Local} {.Local} AnywhereToLocal ReflL = AnywhereToLocal

--- a/LocalGlobal.agda
+++ b/LocalGlobal.agda
@@ -9,12 +9,16 @@ data Locality : Set where
   Unused : Locality -- 0
   Local  : Locality -- 1, i.e., we can do `a [Local] -> a`
   Global : Locality
+  Arb    : Locality
 
 data Ordering : Locality -> Locality -> Set where
 
+  ArbToLocal    : Ordering Arb    Local -- Arb < Local
+  ArbToGlobal   : Ordering Arb    Global -- Arb < Global
   GlobalToLocal : Ordering Global Local -- Global < Local
 
  -- Discussion: (maybe Local < Unused ?)
+ -- JP: order for Unused<->Arb? 
 
 {-
 
@@ -33,11 +37,14 @@ x : Local A /|- t : B
   ReflL         : Ordering Local  Local
   ReflG         : Ordering Global Global
   Refl0         : Ordering Unused Unused
+  ReflA         : Ordering Arb    Arb
 
 _+l_ : Locality -> Locality -> Locality
 Unused +l y      = y
 y      +l Unused = y
 Local  +l Local  = Local
+Arb    +l y      = Arb
+y      +l Arb    = Arb
 x      +l Global = Global
 Global +l y      = Global
 
@@ -45,6 +52,8 @@ _*l_ : Locality -> Locality -> Locality
 Unused *l y      = Unused
 y      *l Unused = Unused
 Local  *l Local  = Local
+Arb    *l x      = Arb
+x      *l Arb    = Arb
 x      *l Global = Global
 Global *l y      = Global
 
@@ -104,24 +113,38 @@ localGlobal =
     reflexive {Local} = ReflL
     reflexive {Global} = ReflG
     reflexive {Unused} = Refl0
+    reflexive {Arb} = ReflA
 
     transt : {r s t : Locality} →
       Ordering r s → Ordering s t → Ordering r t
     transt {.Global} {.Local} {.Local} GlobalToLocal ReflL = GlobalToLocal
+    transt {.Arb} {.Local} {.Local} ArbToLocal ReflL = ArbToLocal
+    transt {.Arb} {.Global} {.Local} ArbToGlobal GlobalToLocal = ArbToLocal
+    transt {.Arb} {.Global} {.Global} ArbToGlobal ReflG = ArbToGlobal
     transt {.Local} {.Local} {.Local} ReflL ReflL = ReflL
     transt {.Global} {.Global} {.Local} ReflG GlobalToLocal = GlobalToLocal
     transt {.Global} {.Global} {.Global} ReflG ReflG = ReflG
     transt {.Unused} {.Unused} {.Unused} Refl0 Refl0 = Refl0
+    transt {.Arb} {.Arb} {.Local} ReflA ArbToLocal = ArbToLocal
+    transt {.Arb} {.Arb} {.Global} ReflA ArbToGlobal = ArbToGlobal
+    transt {.Arb} {.Arb} {.Arb} ReflA ReflA = ReflA
 
     dec<= :  (r s : Locality) → Dec (Ordering r s)
     dec<= Local Local = yes ReflL
     dec<= Local Global = no (λ ())
+    dec<= Local Arb = no (\ ())
     dec<= Local Unused = no (\ ())
     dec<= Global Local = yes GlobalToLocal
     dec<= Global Global = yes ReflG
+    dec<= Global Arb = no (\ ())
     dec<= Global Unused = no (\())
+    dec<= Arb Local = yes ArbToLocal
+    dec<= Arb Global = yes ArbToGlobal
+    dec<= Arb Arb = yes ReflA
+    dec<= Arb Unused = no (\ ())
     dec<= Unused Local = no (\ ())
     dec<= Unused Global = no (\())
+    dec<= Unused Arb = no (\ ())
     dec<= Unused Unused = yes Refl0
 
 
@@ -129,111 +152,243 @@ localGlobal =
     right+ {Local} = refl
     right+ {Global} = refl
     right+ {Unused} = refl
+    right+ {Arb} = refl
 
     commPlus : {x y : Locality} -> (x +l y) ≡ (y +l x)
     commPlus {Local} {Local} = refl
     commPlus {Local} {Global} = refl
     commPlus {Local} {Unused} = refl
+    commPlus {Local} {Arb} = refl
     commPlus {Global} {Local} = refl
     commPlus {Global} {Global} = refl
     commPlus {Global} {Unused} = refl
+    commPlus {Global} {Arb} = refl
     commPlus {Unused} {Local} = refl
     commPlus {Unused} {Global} = refl
     commPlus {Unused} {Unused} = refl
+    commPlus {Unused} {Arb} = refl
+    commPlus {Arb} {Local} = refl
+    commPlus {Arb} {Global} = refl
+    commPlus {Arb} {Unused} = refl
+    commPlus {Arb} {Arb} = refl
 
     leftUnit* : {x : Locality} ->  (Local *l x) ≡ x
     leftUnit* {Local} = refl
     leftUnit* {Global} = refl
     leftUnit* {Unused} = refl
+    leftUnit* {Arb}    = refl
 
     rightUnit* : {x : Locality} ->  (x *l Local) ≡ x
     rightUnit* {Local} = refl
     rightUnit* {Global} = refl
     rightUnit* {Unused} = refl
+    rightUnit* {Arb} = refl
 
     rightabsorb : {x : Locality} → (x *l Unused) ≡ Unused
     rightabsorb {Local} = refl
     rightabsorb {Global} = refl
     rightabsorb {Unused} = refl
+    rightabsorb {Arb} = refl
 
     mon* : {r1 r2 s1 s2 : Locality} →
       Ordering r1 r2 → Ordering s1 s2 → Ordering (r1 *l s1) (r2 *l s2)
     mon* {.Global} {.Local} {.Global} {.Local} GlobalToLocal GlobalToLocal = GlobalToLocal
+    mon* {.Global} {.Local} {.Arb} {.Local} GlobalToLocal ArbToLocal = ArbToLocal
+    mon* {.Global} {.Local} {.Arb} {.Global} GlobalToLocal ArbToGlobal = ArbToGlobal
     mon* {.Global} {.Local} {.Local} {.Local} GlobalToLocal ReflL = GlobalToLocal
     mon* {.Global} {.Local} {.Global} {.Global} GlobalToLocal ReflG = ReflG
     mon* {.Global} {.Local} {.Unused} {.Unused} GlobalToLocal Refl0 = Refl0
+    mon* {.Global} {.Local} {.Arb} {.Arb} GlobalToLocal ReflA = ReflA
+    mon* {.Arb} {.Local} {.Global} {.Local} ArbToLocal GlobalToLocal = ArbToLocal
+    mon* {.Arb} {.Local} {.Arb} {.Local} ArbToLocal ArbToLocal = ArbToLocal
+    mon* {.Arb} {.Local} {.Arb} {.Global} ArbToLocal ArbToGlobal = ArbToGlobal
+    mon* {.Arb} {.Local} {.Local} {.Local} ArbToLocal ReflL = ArbToLocal
+    mon* {.Arb} {.Local} {.Global} {.Global} ArbToLocal ReflG = ArbToGlobal
+    mon* {.Arb} {.Local} {.Unused} {.Unused} ArbToLocal Refl0 = Refl0
+    mon* {.Arb} {.Local} {.Arb} {.Arb} ArbToLocal ReflA = ReflA
+    mon* {.Arb} {.Global} {.Global} {.Local} ArbToGlobal GlobalToLocal = ArbToGlobal
+    mon* {.Arb} {.Global} {.Arb} {.Local} ArbToGlobal ArbToLocal = ArbToGlobal
+    mon* {.Arb} {.Global} {.Arb} {.Global} ArbToGlobal ArbToGlobal = ArbToGlobal
+    mon* {.Arb} {.Global} {.Local} {.Local} ArbToGlobal ReflL = ArbToGlobal
+    mon* {.Arb} {.Global} {.Global} {.Global} ArbToGlobal ReflG = ArbToGlobal
+    mon* {.Arb} {.Global} {.Unused} {.Unused} ArbToGlobal Refl0 = Refl0
+    mon* {.Arb} {.Global} {.Arb} {.Arb} ArbToGlobal ReflA = ReflA
     mon* {.Local} {.Local} {.Global} {.Local} ReflL GlobalToLocal = GlobalToLocal
+    mon* {.Local} {.Local} {.Arb} {.Local} ReflL ArbToLocal = ArbToLocal
+    mon* {.Local} {.Local} {.Arb} {.Global} ReflL ArbToGlobal = ArbToGlobal
     mon* {.Local} {.Local} {.Local} {.Local} ReflL ReflL = ReflL
     mon* {.Local} {.Local} {.Global} {.Global} ReflL ReflG = ReflG
     mon* {.Local} {.Local} {.Unused} {.Unused} ReflL Refl0 = Refl0
+    mon* {.Local} {.Local} {.Arb} {.Arb} ReflL ReflA = ReflA
     mon* {.Global} {.Global} {.Global} {.Local} ReflG GlobalToLocal = ReflG
+    mon* {.Global} {.Global} {.Arb} {.Local} ReflG ArbToLocal = ArbToGlobal
+    mon* {.Global} {.Global} {.Arb} {.Global} ReflG ArbToGlobal = ArbToGlobal
     mon* {.Global} {.Global} {.Local} {.Local} ReflG ReflL = ReflG
     mon* {.Global} {.Global} {.Global} {.Global} ReflG ReflG = ReflG
     mon* {.Global} {.Global} {.Unused} {.Unused} ReflG Refl0 = Refl0
+    mon* {.Global} {.Global} {.Arb} {.Arb} ReflG ReflA = ReflA
     mon* {.Unused} {.Unused} {.Global} {.Local} Refl0 GlobalToLocal = Refl0
+    mon* {.Unused} {.Unused} {.Arb} {.Local} Refl0 ArbToLocal = Refl0
+    mon* {.Unused} {.Unused} {.Arb} {.Global} Refl0 ArbToGlobal = Refl0
     mon* {.Unused} {.Unused} {.Local} {.Local} Refl0 ReflL = Refl0
     mon* {.Unused} {.Unused} {.Global} {.Global} Refl0 ReflG = Refl0
     mon* {.Unused} {.Unused} {.Unused} {.Unused} Refl0 Refl0 = Refl0
+    mon* {.Unused} {.Unused} {.Arb} {.Arb} Refl0 ReflA = Refl0
+    mon* {.Arb} {.Arb} {.Global} {.Local} ReflA GlobalToLocal = ReflA
+    mon* {.Arb} {.Arb} {.Arb} {.Local} ReflA ArbToLocal = ReflA
+    mon* {.Arb} {.Arb} {.Arb} {.Global} ReflA ArbToGlobal = ReflA
+    mon* {.Arb} {.Arb} {.Local} {.Local} ReflA ReflL = ReflA
+    mon* {.Arb} {.Arb} {.Global} {.Global} ReflA ReflG = ReflA
+    mon* {.Arb} {.Arb} {.Unused} {.Unused} ReflA Refl0 = Refl0
+    mon* {.Arb} {.Arb} {.Arb} {.Arb} ReflA ReflA = ReflA
 
     mon+ : {r1 r2 s1 s2 : Locality} →
       Ordering r1 r2 → Ordering s1 s2 → Ordering (r1 +l s1) (r2 +l s2)
     mon+ {.Global} {.Local} {.Global} {.Local} GlobalToLocal GlobalToLocal = GlobalToLocal
+    mon+ {.Global} {.Local} {.Arb} {.Local} GlobalToLocal ArbToLocal = ArbToLocal
+    mon+ {.Global} {.Local} {.Arb} {.Global} GlobalToLocal ArbToGlobal = ArbToGlobal
     mon+ {.Global} {.Local} {.Local} {.Local} GlobalToLocal ReflL = GlobalToLocal
     mon+ {.Global} {.Local} {.Global} {.Global} GlobalToLocal ReflG = ReflG
     mon+ {.Global} {.Local} {.Unused} {.Unused} GlobalToLocal Refl0 = GlobalToLocal
+    mon+ {.Global} {.Local} {.Arb} {.Arb} GlobalToLocal ReflA = ReflA
+    mon+ {.Arb} {.Local} {.Global} {.Local} ArbToLocal GlobalToLocal = ArbToLocal
+    mon+ {.Arb} {.Local} {.Arb} {.Local} ArbToLocal ArbToLocal = ArbToLocal
+    mon+ {.Arb} {.Local} {.Arb} {.Global} ArbToLocal ArbToGlobal = ArbToGlobal
+    mon+ {.Arb} {.Local} {.Local} {.Local} ArbToLocal ReflL = ArbToLocal
+    mon+ {.Arb} {.Local} {.Global} {.Global} ArbToLocal ReflG = ArbToGlobal
+    mon+ {.Arb} {.Local} {.Unused} {.Unused} ArbToLocal Refl0 = ArbToLocal
+    mon+ {.Arb} {.Local} {.Arb} {.Arb} ArbToLocal ReflA = ReflA
+    mon+ {.Arb} {.Global} {.Global} {.Local} ArbToGlobal GlobalToLocal = ArbToGlobal
+    mon+ {.Arb} {.Global} {.Arb} {.Local} ArbToGlobal ArbToLocal = ArbToGlobal
+    mon+ {.Arb} {.Global} {.Arb} {.Global} ArbToGlobal ArbToGlobal = ArbToGlobal
+    mon+ {.Arb} {.Global} {.Local} {.Local} ArbToGlobal ReflL = ArbToGlobal
+    mon+ {.Arb} {.Global} {.Global} {.Global} ArbToGlobal ReflG = ArbToGlobal
+    mon+ {.Arb} {.Global} {.Unused} {.Unused} ArbToGlobal Refl0 = ArbToGlobal
+    mon+ {.Arb} {.Global} {.Arb} {.Arb} ArbToGlobal ReflA = ReflA
     mon+ {.Local} {.Local} {.Global} {.Local} ReflL GlobalToLocal = GlobalToLocal
+    mon+ {.Local} {.Local} {.Arb} {.Local} ReflL ArbToLocal = ArbToLocal
+    mon+ {.Local} {.Local} {.Arb} {.Global} ReflL ArbToGlobal = ArbToGlobal
     mon+ {.Local} {.Local} {.Local} {.Local} ReflL ReflL = ReflL
     mon+ {.Local} {.Local} {.Global} {.Global} ReflL ReflG = ReflG
     mon+ {.Local} {.Local} {.Unused} {.Unused} ReflL Refl0 = ReflL
+    mon+ {.Local} {.Local} {.Arb} {.Arb} ReflL ReflA = ReflA
     mon+ {.Global} {.Global} {.Global} {.Local} ReflG GlobalToLocal = ReflG
+    mon+ {.Global} {.Global} {.Arb} {.Local} ReflG ArbToLocal = ArbToGlobal
+    mon+ {.Global} {.Global} {.Arb} {.Global} ReflG ArbToGlobal = ArbToGlobal
     mon+ {.Global} {.Global} {.Local} {.Local} ReflG ReflL = ReflG
     mon+ {.Global} {.Global} {.Global} {.Global} ReflG ReflG = ReflG
     mon+ {.Global} {.Global} {.Unused} {.Unused} ReflG Refl0 = ReflG
+    mon+ {.Global} {.Global} {.Arb} {.Arb} ReflG ReflA = ReflA
     mon+ {.Unused} {.Unused} {.Global} {.Local} Refl0 GlobalToLocal = GlobalToLocal
+    mon+ {.Unused} {.Unused} {.Arb} {.Local} Refl0 ArbToLocal = ArbToLocal
+    mon+ {.Unused} {.Unused} {.Arb} {.Global} Refl0 ArbToGlobal = ArbToGlobal
     mon+ {.Unused} {.Unused} {.Local} {.Local} Refl0 ReflL = ReflL
     mon+ {.Unused} {.Unused} {.Global} {.Global} Refl0 ReflG = ReflG
     mon+ {.Unused} {.Unused} {.Unused} {.Unused} Refl0 Refl0 = Refl0
+    mon+ {.Unused} {.Unused} {.Arb} {.Arb} Refl0 ReflA = ReflA
+    mon+ {.Arb} {.Arb} {.Global} {.Local} ReflA GlobalToLocal = ReflA
+    mon+ {.Arb} {.Arb} {.Arb} {.Local} ReflA ArbToLocal = ReflA
+    mon+ {.Arb} {.Arb} {.Arb} {.Global} ReflA ArbToGlobal = ReflA
+    mon+ {.Arb} {.Arb} {.Local} {.Local} ReflA ReflL = ReflA
+    mon+ {.Arb} {.Arb} {.Global} {.Global} ReflA ReflG = ReflA
+    mon+ {.Arb} {.Arb} {.Unused} {.Unused} ReflA Refl0 = ReflA
+    mon+ {.Arb} {.Arb} {.Arb} {.Arb} ReflA ReflA = ReflA
 
     assoc* : {r s t : Locality} → ((r *l s) *l t) ≡ (r *l (s *l t))
     assoc* {Local} {Local} {Local} = refl
     assoc* {Local} {Local} {Global} = refl
+    assoc* {Local} {Local} {Arb} = refl
     assoc* {Local} {Local} {Unused} = refl
     assoc* {Local} {Global} {Local} = refl
     assoc* {Local} {Global} {Global} = refl
+    assoc* {Local} {Global} {Arb} = refl
     assoc* {Local} {Global} {Unused} = refl
+    assoc* {Local} {Arb} {Local} = refl
+    assoc* {Local} {Arb} {Global} = refl
+    assoc* {Local} {Arb} {Arb} = refl
+    assoc* {Local} {Arb} {Unused} = refl
     assoc* {Local} {Unused} {t} = refl
     assoc* {Global} {Local} {Local} = refl
     assoc* {Global} {Local} {Global} = refl
+    assoc* {Global} {Local} {Arb} = refl
     assoc* {Global} {Local} {Unused} = refl
     assoc* {Global} {Global} {Local} = refl
     assoc* {Global} {Global} {Global} = refl
+    assoc* {Global} {Global} {Arb} = refl
     assoc* {Global} {Global} {Unused} = refl
+    assoc* {Global} {Arb} {Local} = refl
+    assoc* {Global} {Arb} {Global} = refl
+    assoc* {Global} {Arb} {Arb} = refl
+    assoc* {Global} {Arb} {Unused} = refl
     assoc* {Global} {Unused} {t} = refl
+    assoc* {Arb} {Local} {Local} = refl
+    assoc* {Arb} {Local} {Global} = refl
+    assoc* {Arb} {Local} {Arb} = refl
+    assoc* {Arb} {Local} {Unused} = refl
+    assoc* {Arb} {Global} {Local} = refl
+    assoc* {Arb} {Global} {Global} = refl
+    assoc* {Arb} {Global} {Arb} = refl
+    assoc* {Arb} {Global} {Unused} = refl
+    assoc* {Arb} {Arb} {Local} = refl
+    assoc* {Arb} {Arb} {Global} = refl
+    assoc* {Arb} {Arb} {Arb} = refl
+    assoc* {Arb} {Arb} {Unused} = refl
+    assoc* {Arb} {Unused} {t} = refl
     assoc* {Unused} {s} {t} = refl
 
     distrib1 : {r s t : Locality} → (r *l (s +l t)) ≡ ((r *l s) +l (r *l t))
     distrib1 {Local} {s} {t} rewrite leftUnit* {s +l t} | leftUnit* {s} | leftUnit* {t} = refl
     distrib1 {Global} {Local} {Local} = refl
     distrib1 {Global} {Local} {Global} = refl
+    distrib1 {Global} {Local} {Arb} = refl
     distrib1 {Global} {Local} {Unused} = refl
     distrib1 {Global} {Global} {Local} = refl
     distrib1 {Global} {Global} {Global} = refl
+    distrib1 {Global} {Global} {Arb} = refl
     distrib1 {Global} {Global} {Unused} = refl
+    distrib1 {Global} {Arb} {Local} = refl
+    distrib1 {Global} {Arb} {Global} = refl
+    distrib1 {Global} {Arb} {Arb} = refl
+    distrib1 {Global} {Arb} {Unused} = refl
     distrib1 {Global} {Unused} {Local} = refl
     distrib1 {Global} {Unused} {Global} = refl
+    distrib1 {Global} {Unused} {Arb} = refl
     distrib1 {Global} {Unused} {Unused} = refl
+    distrib1 {Arb} {Local} {Local} = refl
+    distrib1 {Arb} {Local} {Global} = refl
+    distrib1 {Arb} {Local} {Arb} = refl
+    distrib1 {Arb} {Local} {Unused} = refl
+    distrib1 {Arb} {Global} {Local} = refl
+    distrib1 {Arb} {Global} {Global} = refl
+    distrib1 {Arb} {Global} {Arb} = refl
+    distrib1 {Arb} {Global} {Unused} = refl
+    distrib1 {Arb} {Arb} {Local} = refl
+    distrib1 {Arb} {Arb} {Global} = refl
+    distrib1 {Arb} {Arb} {Arb} = refl
+    distrib1 {Arb} {Arb} {Unused} = refl
+    distrib1 {Arb} {Unused} {Local} = refl
+    distrib1 {Arb} {Unused} {Global} = refl
+    distrib1 {Arb} {Unused} {Arb} = refl
+    distrib1 {Arb} {Unused} {Unused} = refl
     distrib1 {Unused} {s} {t} = refl
 
     -- used by distrib2
     comm* : {x y : Locality} -> x *l y ≡ y *l x
     comm* {Local} {Local} = refl
     comm* {Local} {Global} = refl
+    comm* {Local} {Arb} = refl
     comm* {Local} {Unused} = refl
     comm* {Global} {Local} = refl
     comm* {Global} {Global} = refl
+    comm* {Global} {Arb} = refl
     comm* {Global} {Unused} = refl
+    comm* {Arb} {Local} = refl
+    comm* {Arb} {Global} = refl
+    comm* {Arb} {Arb} = refl
+    comm* {Arb} {Unused} = refl
     comm* {Unused} {Local} = refl
     comm* {Unused} {Global} = refl
+    comm* {Unused} {Arb} = refl
     comm* {Unused} {Unused} = refl
 
     distrib2prop : {r s t : Locality} → ((r +l s) *l t) ≡ ((r *l t) +l (s *l t))
@@ -242,16 +397,41 @@ localGlobal =
     assocPlus : {r s t : Locality} → ((r +l s) +l t) ≡ (r +l (s +l t))
     assocPlus {Local} {Local} {Local} = refl
     assocPlus {Local} {Local} {Global} = refl
+    assocPlus {Local} {Local} {Arb} = refl
     assocPlus {Local} {Local} {Unused} = refl
     assocPlus {Local} {Global} {Local} = refl
     assocPlus {Local} {Global} {Global} = refl
+    assocPlus {Local} {Global} {Arb} = refl
     assocPlus {Local} {Global} {Unused} = refl
+    assocPlus {Local} {Arb} {Local} = refl
+    assocPlus {Local} {Arb} {Global} = refl
+    assocPlus {Local} {Arb} {Arb} = refl
+    assocPlus {Local} {Arb} {Unused} = refl
     assocPlus {Local} {Unused} {t} = refl
     assocPlus {Global} {Local} {Local} = refl
     assocPlus {Global} {Local} {Global} = refl
+    assocPlus {Global} {Local} {Arb} = refl
     assocPlus {Global} {Local} {Unused} = refl
     assocPlus {Global} {Global} {Local} = refl
     assocPlus {Global} {Global} {Global} = refl
+    assocPlus {Global} {Global} {Arb} = refl
     assocPlus {Global} {Global} {Unused} = refl
+    assocPlus {Global} {Arb} {Local} = refl
+    assocPlus {Global} {Arb} {Global} = refl
+    assocPlus {Global} {Arb} {Arb} = refl
+    assocPlus {Global} {Arb} {Unused} = refl
     assocPlus {Global} {Unused} {t} = refl
+    assocPlus {Arb} {Local} {Local} = refl
+    assocPlus {Arb} {Local} {Global} = refl
+    assocPlus {Arb} {Local} {Arb} = refl
+    assocPlus {Arb} {Local} {Unused} = refl
+    assocPlus {Arb} {Global} {Local} = refl
+    assocPlus {Arb} {Global} {Global} = refl
+    assocPlus {Arb} {Global} {Arb} = refl
+    assocPlus {Arb} {Global} {Unused} = refl
+    assocPlus {Arb} {Arb} {Local} = refl
+    assocPlus {Arb} {Arb} {Global} = refl
+    assocPlus {Arb} {Arb} {Arb} = refl
+    assocPlus {Arb} {Arb} {Unused} = refl
+    assocPlus {Arb} {Unused} {t} = refl
     assocPlus {Unused} {s} {t} = refl


### PR DESCRIPTION
This version has 1 as Anywhere, with 

```
Global < Anywhere < Local
```

Global values may be heap-allocated.

Local values should be stack-allocated.

A Local **can** reference a Global. A Global **cannot** reference a Local.

Therefore a Global can be used where a Local is expected, not vice-versa (`Global < Local`).

Primitives which heap allocate could (should?) be updated (wip):

(update: actually these should be updated such that `{l1 l2 : Locality, l1 >= l2} . (Ref (a [l2])) [l1]` so they can be locally allocated)

```
newRef : forall {a : Type} . a  -> exists {id : Name} . *(Ref id (a [Global]))

swapRef : forall {a : Type, f : Fraction, id : Name} . {mut f} => & f (Ref id (a [Global])) -> a -> ((a [Global]), & f (Ref id (a [Global])))
```

```
-- not allowed
bad : Float [Local] -> Ref (Int [Global])
bad x = newRef x

-- allowed
good : Float -> Ref (Int [Global])
good x = newRef x
```

`Anywhere < Local` and `Global < Anywhere` should permit these changes without breaking existing programs (? TBC).
